### PR TITLE
Use native `browser.*` APIs when available

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -126,10 +126,10 @@ if (typeof chrome === 'object' && !chrome.contentScripts) {
 				});
 			};
 
-			void browser.tabs.onUpdated.addListener(listener);
+			chrome.tabs.onUpdated.addListener(listener);
 			const registeredContentScript = {
 				async unregister() {
-					return browser.tabs.onUpdated.removeListener(listener);
+					return chrome.tabs.onUpdated.removeListener(listener);
 				}
 			};
 

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,6 @@
 import chromeP from 'webext-polyfill-kinda';
 import {patternToRegex} from 'webext-patterns';
 
-
 async function isOriginPermitted(url: string): Promise<boolean> {
 	return chromeP.permissions.contains({
 		origins: [new URL(url).origin + '/*']

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
 	},
 	"dependencies": {
 		"@types/firefox-webext-browser": "^78.0.1",
-		"webext-patterns": "^0.9.0"
+		"webext-patterns": "^0.9.0",
+		"webext-polyfill-kinda": "0.0.1"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^0.7.0",


### PR DESCRIPTION
Partial fix for #5 