### PR TITLE
Preserve raw `code` execution order

### DIFF
--- a/ponyfill.ts
+++ b/ponyfill.ts
@@ -76,14 +76,15 @@ export default async function registerContentScript(
 			});
 		}
 
-		let lastInjectionPromise: Promise<unknown> | undefined;
+		let lastInjection: Promise<unknown> | undefined;
 		for (const file of js) {
+			// Files are executed in order, but code isn’t, so it must wait the last script #31
 			if ('code' in file) {
-				// eslint-disable-next-line no-await-in-loop
-				await lastInjectionPromise;
+				// eslint-disable-next-line no-await-in-loop -- On purpose, to serialize injection
+				await lastInjection;
 			}
 
-			lastInjectionPromise = chromeP.tabs.executeScript(tabId, {
+			lastInjection = chromeP.tabs.executeScript(tabId, {
 				...file,
 				matchAboutBlank,
 				allFrames,

--- a/ponyfill.ts
+++ b/ponyfill.ts
@@ -57,6 +57,12 @@ export default async function registerContentScript(
 
 	const matchesRegex = patternToRegex(...matches);
 
+	const asyncExecuteScript = async (tabId: number, details: chrome.tabs.InjectDetails) => {
+		return new Promise(resolve => {
+			chrome.tabs.executeScript(tabId, details, resolve);
+		});
+	};
+
 	const inject = async (url: string, tabId: number, frameId?: number) => {
 		if (
 			!matchesRegex.test(url) || // Manual `matches` glob matching
@@ -77,7 +83,8 @@ export default async function registerContentScript(
 		}
 
 		for (const file of js) {
-			void chrome.tabs.executeScript(tabId, {
+			// eslint-disable-next-line no-await-in-loop
+			await asyncExecuteScript(tabId, {
 				...file,
 				matchAboutBlank,
 				allFrames,

--- a/test/demo-extension/background.js
+++ b/test/demo-extension/background.js
@@ -11,7 +11,10 @@ if (window.browser?.contentScripts.register) {
 (window.browser?.contentScripts.register ?? contentScriptsRegister)({
 	allFrames: true,
 	matches: ['https://iframe-test-page.vercel.app/*'],
-	js: [{file: 'dynamic.js'}],
+	js: [
+		{file: 'dynamic.js'},
+		{code: 'document.body.insertAdjacentHTML(\'beforeEnd\', \'<p class="dynamic-code">This should be second</p>\');'}
+	],
 	css: [{file: 'dynamic.css'}]
 });
 

--- a/test/demo-extension/dynamic.js
+++ b/test/demo-extension/dynamic.js
@@ -1,2 +1,2 @@
-document.body.insertAdjacentHTML('beforeEnd', '<p class="dynamic">Dynamic script loaded');
+document.body.insertAdjacentHTML('beforeEnd', '<p class="dynamic">Dynamic script loaded</p>');
 console.log('Dynamic script loaded', new Date());

--- a/test/test.js
+++ b/test/test.js
@@ -19,8 +19,16 @@ describe('tab', () => {
 		await expect(page).toMatchElement('.static');
 	});
 
-	it('should load dynamic content script', async () => {
+	it('should load file based dynamic content script', async () => {
 		await expect(page).toMatchElement('.dynamic');
+	});
+
+	it('should load code based dynamic content script', async () => {
+		await expect(page).toMatchElement('.dynamic-code');
+	});
+
+	it('should execute dynamic content scripts in the right order', async () => {
+		await expect(page).toMatchElement('.dynamic + .dynamic-code');
 	});
 
 	it('should load static content script after a reload', async () => {
@@ -28,9 +36,14 @@ describe('tab', () => {
 		await expect(page).toMatchElement('.static');
 	});
 
-	it('should load dynamic content script after a reload', async () => {
+	it('should load file based dynamic content script after a reload', async () => {
 		await page.reload();
 		await expect(page).toMatchElement('.dynamic');
+	});
+
+	it('should load code based dynamic content script after a reload', async () => {
+		await page.reload();
+		await expect(page).toMatchElement('.dynamic-code');
 	});
 });
 
@@ -49,8 +62,16 @@ describe('iframe', () => {
 		await expect(iframe).toMatchElement('.static');
 	});
 
-	it('should load dynamic content script', async () => {
+	it('should load file based dynamic content script', async () => {
 		await expect(iframe).toMatchElement('.dynamic');
+	});
+
+	it('should load code based dynamic content script', async () => {
+		await expect(iframe).toMatchElement('.dynamic-code');
+	});
+
+	it('should execute dynamic content scripts in the right order', async () => {
+		await expect(page).toMatchElement('.dynamic + .dynamic-code');
 	});
 
 	it('should load static content script after a reload', async () => {
@@ -58,9 +79,14 @@ describe('iframe', () => {
 		await expect(iframe).toMatchElement('.static');
 	});
 
-	it('should load dynamic content script after a reload', async () => {
+	it('should load file based dynamic content script after a reload', async () => {
 		await iframe.goto(iframe.url());
 		await expect(iframe).toMatchElement('.dynamic');
+	});
+
+	it('should load code based dynamic content script after a reload', async () => {
+		await iframe.goto(iframe.url());
+		await expect(iframe).toMatchElement('.dynamic-code');
 	});
 });
 


### PR DESCRIPTION
First of all, great job with this polyfill 👏 

I found out a little bug while trying to inject a couple of scripts at once - some with `file` attribute and some with `code`.
According to [documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#js):
> Files are injected in the order given.

Currently, this works (probably) fine when all of the scripts are "`file` based" or all of them are "`code` based".

But I found out that when I try to register such a script:
```js
// --- some-file.js ---

console.log('hello from file')


// -- background.js --

window.browser.contentScripts.register({
  matches: ['*://*.com/*'],
  js: [
    {file: 'some-file.js'},
    {code: 'console.log("hello from code")'}
  ],
})
```

I got unexpected result:
```
> hello from code
> hello from file
```

I decided to write a simple regression test and a simple solution for that. I would appreciate it if you would review this code. I am happy to make changes as needed.