### PR TITLE
Add support for `exclude_matches`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,9 @@ const registeredScript = await registerContentScript({
 	}],
 	matches: [
 		'https://google.com/*'
+	],
+	excludeMatches: [ // Also supported
+		'https://google.com/search*'
 	]
 });
 ```

--- a/test/demo-extension/background.js
+++ b/test/demo-extension/background.js
@@ -18,4 +18,15 @@ if (window.browser?.contentScripts.register) {
 	css: [{file: 'dynamic.css'}],
 });
 
+(window.browser?.contentScripts.register ?? contentScriptsRegister)({
+	allFrames: true,
+	matches: ['https://fregante.github.io/pixiebrix-testing-ground/*'],
+	excludeMatches: ['https://fregante.github.io/pixiebrix-testing-ground/Parent-page*'],
+	js: [
+		{file: 'dynamic.js'},
+		{code: 'document.body.insertAdjacentHTML(\'beforeEnd\', \'<p class="dynamic-code">This should be second</p>\');'},
+	],
+	css: [{file: 'dynamic.css'}],
+});
+
 console.log('Script registered');

--- a/test/demo-extension/manifest.json
+++ b/test/demo-extension/manifest.json
@@ -5,7 +5,8 @@
 	"permissions": [
 		"webNavigation",
 		"https://iframe-test-page.vercel.app/*",
-		"https://iframe-test-page-n786423ca-fregante.vercel.app/*"
+		"https://iframe-test-page-n786423ca-fregante.vercel.app/*",
+		"https://fregante.github.io/*"
 	],
 	"background": {
 		"scripts": [
@@ -29,6 +30,21 @@
 			"all_frames": true,
 			"matches": [
 				"https://iframe-test-page-n786423ca-fregante.vercel.app/*"
+			],
+			"js": [
+				"static.js"
+			],
+			"css": [
+				"static.css"
+			]
+		},
+		{
+			"all_frames": true,
+			"matches": [
+				"https://fregante.github.io/pixiebrix-testing-ground/*"
+			],
+			"exclude_matches": [
+				"https://fregante.github.io/pixiebrix-testing-ground/Parent-page*"
 			],
 			"js": [
 				"static.js"


### PR DESCRIPTION
Part of #35 

executeScript does not support `execute_matches`, so I'm using `webext-patterns`

- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript
- https://developer.chrome.com/docs/extensions/mv3/content_scripts/#matchAndGlob