### PR TITLE
Add support for Manifest v3

### DIFF
--- a/.github/workflows/esm-lint.yml
+++ b/.github/workflows/esm-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm install
       - run: npm run build --if-present
       - run: npm pack --dry-run
-      - run: npm pack --silent 2>/dev/null | xargs -n1 tar -xzf
+      - run: npm pack | tail -1 | xargs -n1 tar -xzf
       - uses: actions/upload-artifact@v2
         with:
           path: package
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/download-artifact@v2
       - run: npm install ./artifact
       - run: echo "${{ env.IMPORT_TEXT }} '${{ env.NPM_MODULE_NAME }}'" > index.js
-      - run: npx parcel@2.0.0-beta.2 build index.js
+      - run: npx parcel@2 build index.js
       - run: cat dist/index.js
   Rollup:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "3.1.0",
 			"license": "MIT",
 			"dependencies": {
+				"webext-content-scripts": "^0.11.1",
 				"webext-patterns": "^1.1.1",
 				"webext-polyfill-kinda": "^0.9.0"
 			},
@@ -16151,6 +16152,17 @@
 			"integrity": "sha512-5LDIv+sr6uzT94Hhcq7Qv7gt3jxol4iMWUqOgJSLYbB5oO7bTSMqIBtKsytm8N2BufYOdJw86/qu+SDfbo/wKQ==",
 			"dev": true
 		},
+		"node_modules/webext-content-scripts": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-0.11.1.tgz",
+			"integrity": "sha512-n2KCPCL2IeRs4UHVutouDqkZpF9o0NfSx204/TfriE70Sw9CkDCq6gAde5GwOMoqewa13U9GujEgy6j6GVDjaQ==",
+			"dependencies": {
+				"webext-polyfill-kinda": "^0.9.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
+		},
 		"node_modules/webext-patterns": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/webext-patterns/-/webext-patterns-1.1.1.tgz",
@@ -29642,6 +29654,14 @@
 			"resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.1.3.tgz",
 			"integrity": "sha512-5LDIv+sr6uzT94Hhcq7Qv7gt3jxol4iMWUqOgJSLYbB5oO7bTSMqIBtKsytm8N2BufYOdJw86/qu+SDfbo/wKQ==",
 			"dev": true
+		},
+		"webext-content-scripts": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-0.11.1.tgz",
+			"integrity": "sha512-n2KCPCL2IeRs4UHVutouDqkZpF9o0NfSx204/TfriE70Sw9CkDCq6gAde5GwOMoqewa13U9GujEgy6j6GVDjaQ==",
+			"requires": {
+				"webext-polyfill-kinda": "^0.9.0"
+			}
 		},
 		"webext-patterns": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		]
 	},
 	"dependencies": {
+		"webext-content-scripts": "^0.11.1",
 		"webext-patterns": "^1.1.1",
 		"webext-polyfill-kinda": "^0.9.0"
 	},

--- a/ponyfill.ts
+++ b/ponyfill.ts
@@ -63,7 +63,7 @@ export default async function registerContentScript(
 	const matchesRegex = patternToRegex(...matches);
 	const excludeMatchesRegex = patternToRegex(...excludeMatches ?? []);
 
-	const inject = async (url: string, tabId: number, frameId: number = 0) => {
+	const inject = async (url: string, tabId: number, frameId = 0) => {
 		if (
 			!matchesRegex.test(url) // Manual `matches` glob matching
 			|| excludeMatchesRegex.test(url) // Manual `exclude_matches` glob matching

--- a/ponyfill.ts
+++ b/ponyfill.ts
@@ -1,9 +1,16 @@
+import {executeFunction} from 'webext-content-scripts';
 import chromeP from 'webext-polyfill-kinda';
 import {patternToRegex} from 'webext-patterns';
 
 // https://www.typescriptlang.org/docs/handbook/namespaces.html#aliases
 import CS = browser.contentScripts;
 
+interface Target {
+	tabId: number;
+	frameId: number;
+}
+
+const gotScripting = typeof chrome === 'object' && 'scripting' in chrome;
 const gotNavigation = typeof chrome === 'object' && 'webNavigation' in chrome;
 
 async function isOriginPermitted(url: string): Promise<boolean> {
@@ -12,10 +19,13 @@ async function isOriginPermitted(url: string): Promise<boolean> {
 	});
 }
 
+function arrayOrUndefined<X>(value?: X): [X] | undefined {
+	return typeof value === 'undefined' ? undefined : [value];
+}
+
 async function wasPreviouslyLoaded(
-	tabId: number,
-	frameId: number | undefined,
-	args: Record<string, any>,
+	target: Target,
+	arg: Record<string, any>,
 ): Promise<boolean> {
 	// Checks and sets a global variable
 	const loadCheck = (key: string): boolean => {
@@ -27,13 +37,7 @@ async function wasPreviouslyLoaded(
 		return wasLoaded;
 	};
 
-	// Safe code injection + argument passing
-	const result = await chromeP.tabs.executeScript(tabId, {
-		frameId,
-		code: `(${loadCheck.toString()})(${JSON.stringify(args)})`,
-	});
-
-	return result?.[0] as boolean;
+	return executeFunction(target, loadCheck, arg);
 }
 
 // The callback is only used by webextension-polyfill
@@ -59,41 +63,68 @@ export default async function registerContentScript(
 	const matchesRegex = patternToRegex(...matches);
 	const excludeMatchesRegex = patternToRegex(...excludeMatches ?? []);
 
-	const inject = async (url: string, tabId: number, frameId?: number) => {
+	const inject = async (url: string, tabId: number, frameId: number = 0) => {
 		if (
 			!matchesRegex.test(url) // Manual `matches` glob matching
 			|| excludeMatchesRegex.test(url) // Manual `exclude_matches` glob matching
 			|| !await isOriginPermitted(url) // Without this, we might have temporary access via accessTab
-			|| await wasPreviouslyLoaded(tabId, frameId, {js, css}) // Avoid double-injection
+			|| await wasPreviouslyLoaded({tabId, frameId}, {js, css}) // Avoid double-injection
 		) {
 			return;
 		}
 
-		for (const file of css) {
-			void chrome.tabs.insertCSS(tabId, {
-				...file,
-				matchAboutBlank,
-				allFrames,
-				frameId,
-				runAt: runAt ?? 'document_start', // CSS should prefer `document_start` when unspecified
-			});
+		for (const content of css) {
+			if (gotScripting) {
+				void chrome.scripting.insertCSS({
+					target: {
+						tabId,
+						frameIds: arrayOrUndefined(frameId),
+						allFrames,
+					},
+					files: 'file' in content ? [content.file] : undefined,
+					css: 'code' in content ? content.code : undefined,
+				});
+			} else {
+				void chromeP.tabs.insertCSS(tabId, {
+					...content,
+					matchAboutBlank,
+					allFrames,
+					frameId,
+					runAt: runAt ?? 'document_start', // CSS should prefer `document_start` when unspecified
+				});
+			}
 		}
 
 		let lastInjection: Promise<unknown> | undefined;
-		for (const file of js) {
-			// Files are executed in order, but code isn’t, so it must wait the last script #31
-			if ('code' in file) {
-				// eslint-disable-next-line no-await-in-loop -- On purpose, to serialize injection
-				await lastInjection;
-			}
+		for (const content of js) {
+			if (gotScripting) {
+				if ('code' in content) {
+					throw new Error('chrome.scripting does not support injecting strings of `code`');
+				}
 
-			lastInjection = chromeP.tabs.executeScript(tabId, {
-				...file,
-				matchAboutBlank,
-				allFrames,
-				frameId,
-				runAt,
-			});
+				void chrome.scripting.executeScript({
+					target: {
+						tabId,
+						frameIds: arrayOrUndefined(frameId),
+						allFrames,
+					},
+					files: [content.file],
+				});
+			} else {
+				// Files are executed in order, but code isn’t, so it must wait the last script #31
+				if ('code' in content) {
+					// eslint-disable-next-line no-await-in-loop -- On purpose, to serialize injection
+					await lastInjection;
+				}
+
+				lastInjection = chromeP.tabs.executeScript(tabId, {
+					...content,
+					matchAboutBlank,
+					allFrames,
+					frameId,
+					runAt,
+				});
+			}
 		}
 	};
 

--- a/test/demo-extension/background.js
+++ b/test/demo-extension/background.js
@@ -2,13 +2,13 @@ import contentScriptsRegister from '../../ponyfill';
 
 console.log('Background loaded');
 
-if (window.browser?.contentScripts.register) {
+if (globalThis.browser?.contentScripts.register) {
 	console.log('Using native implementation');
 } else {
 	console.log('Using polyfill');
 }
 
-(window.browser?.contentScripts.register ?? contentScriptsRegister)({
+(globalThis.browser?.contentScripts.register ?? contentScriptsRegister)({
 	allFrames: true,
 	matches: ['https://iframe-test-page.vercel.app/*'],
 	js: [
@@ -18,7 +18,7 @@ if (window.browser?.contentScripts.register) {
 	css: [{file: 'dynamic.css'}],
 });
 
-(window.browser?.contentScripts.register ?? contentScriptsRegister)({
+(globalThis.browser?.contentScripts.register ?? contentScriptsRegister)({
 	allFrames: true,
 	matches: ['https://fregante.github.io/pixiebrix-testing-ground/*'],
 	excludeMatches: ['https://fregante.github.io/pixiebrix-testing-ground/Parent-page*'],


### PR DESCRIPTION
This adds support for Manifest v3 via the existing logic

- Part of https://github.com/fregante/content-scripts-register-polyfill/issues/11