### PR TITLE
Restore support for multiple registrations on the same host

### DIFF
--- a/ponyfill.ts
+++ b/ponyfill.ts
@@ -20,7 +20,7 @@ async function isOriginPermitted(url: string): Promise<boolean> {
 
 async function wasPreviouslyLoaded(
 	target: Target,
-	arg: Record<string, any>,
+	assets: Record<string, any>,
 ): Promise<boolean> {
 	// Checks and sets a global variable
 	const loadCheck = (key: string): boolean => {
@@ -32,8 +32,8 @@ async function wasPreviouslyLoaded(
 		return wasLoaded;
 	};
 
-	// Stringify the received arg as a hash, to fix the situation where every object gets converted to `[object Object]`.
-	return executeFunction(target, loadCheck, JSON.stringify(arg));
+	// The assets object is used as a key on `document`
+	return executeFunction(target, loadCheck, JSON.stringify(assets));
 }
 
 // The callback is only used by webextension-polyfill

--- a/ponyfill.ts
+++ b/ponyfill.ts
@@ -32,7 +32,8 @@ async function wasPreviouslyLoaded(
 		return wasLoaded;
 	};
 
-	return executeFunction(target, loadCheck, arg);
+	// Stringify the received arg as a hash, to fix the situation where every object gets converted to `[object Object]`.
+	return executeFunction(target, loadCheck, JSON.stringify(arg));
 }
 
 // The callback is only used by webextension-polyfill


### PR DESCRIPTION
In `wasPreviouslyLoaded`, the `arg` is directly used as a object key so inexplict toString is used to transform `arg` into a string. Very unfortunately on the call site the `arg` passed in is `{ css, js }`, which means no matter whatever value `css` or `js` is, it always translate to `[object Object]`.

This bug makes it impossible to register multiple scripts for a tab.

This is probably not the best fix, as `css` or `js` can be very huge, thus `JSON.stringify` can spend a lot of time doing its job.

Sorry for submitting PR w/o discussion. I used this solution to fix my near-production product, so I think I might just as well send it here.